### PR TITLE
Update README deprecated "webpackMode" in favor of "fetch"

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ the `@symfony/ux-dropzone/src/style.css` autoimport to `false`:
         "@symfony/ux-dropzone": {
             "dropzone": {
                 "enabled": true,
-                "webpackMode": "eager",
+                "fetch": "eager",
                 "autoimport": {
                     "@symfony/ux-dropzone/src/style.css": false
                 }


### PR DESCRIPTION
After @weaverryan https://github.com/symfony/stimulus-bridge/pull/15 PR

Encore complains:
`The "webpackMode" config key is deprecated in controllers.json. Use "fetch" instead, set to either "eager" or "lazy".`