### PR TITLE
Update docs which gave a deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ the `@symfony/ux-dropzone/src/style.css` autoimport to `false`:
         "@symfony/ux-dropzone": {
             "dropzone": {
                 "enabled": true,
-                "webpackMode": "eager",
+                "fetch": "eager",
                 "autoimport": {
                     "@symfony/ux-dropzone/src/style.css": false
                 }


### PR DESCRIPTION
Fixed following warning:
```
Module Warning (from ./node_modules/@symfony/stimulus-bridge/dist/webpack/loader.js):
The "webpackMode" config key is deprecated in controllers.json. Use "fetch" instead, set to either "eager" or "lazy".
```